### PR TITLE
Fix: migrate CrossRefDiscoverer to /beta/datacitations (Event Data shut down)

### DIFF
--- a/.specify/specs/citations-collector-core.md
+++ b/.specify/specs/citations-collector-core.md
@@ -212,7 +212,7 @@ As a maintainer, I want a GitHub Actions workflow that periodically updates cita
 
 ### Edge Cases
 
-- CrossRef cited-by requires Polite pool (email in User-Agent) for better rate limits
+- CrossRef data-citations API requires Polite pool (email in User-Agent, plus `mailto` query parameter for the `/beta/datacitations` endpoint) for better rate limits
 - OpenCitations may have delayed indexing (weeks behind CrossRef)
 - Zotero API rate limits: 6 requests/second for single-key auth
 - Large collections: batch API calls, implement progress reporting
@@ -223,9 +223,9 @@ As a maintainer, I want a GitHub Actions workflow that periodically updates cita
 
 APIs support date-based filtering for efficient incremental queries:
 
-- **CrossRef**: `from-index-date` filter with ISO timestamps (second resolution)
-  - Example: `?filter=from-index-date:2024-01-15T00:00:00`
-  - Use `from-index-date` over `from-created-date` for incremental updates
+- **CrossRef** (`/beta/datacitations`): `from-created-date` query parameter (date only, `YYYY-MM-DD`)
+  - Example: `?object-id=<DOI>&from-created-date=2024-01-15`
+  - Filters by ingestion timestamp into CrossRef's data-citations database (~5 day lag from member deposit)
 - **OpenCitations**: `filter=date:>YYYY-MM-DD` parameter
   - Example: `?filter=date:>2024-01-15`
 - **DataCite**: `registered` filter supports date ranges
@@ -241,7 +241,7 @@ The system should:
 ### Functional Requirements
 
 **Citation Discovery:**
-- **FR-001**: System MUST discover papers citing a DOI via CrossRef cited-by API
+- **FR-001**: System MUST discover papers citing a DOI via the CrossRef data-citations API (`api.crossref.org/beta/datacitations`)
 - **FR-002**: System MUST discover papers citing a DOI via OpenCitations (OCI) API
 - **FR-003**: System MUST discover papers citing a DOI via DataCite API
 - **FR-004**: System MUST merge and deduplicate results from multiple sources
@@ -325,8 +325,8 @@ Generated outputs:
 
 **Non-schema classes (implementation):**
 - **CitationDiscoverer**: Queries external APIs for citing papers
-  - Sources: CrossRef (cited-by), OpenCitations (OCI), DataCite, SciCrunch (RRID)
-  - Supports incremental queries via date filters (`from-index-date`, `filter=date:>`)
+  - Sources: CrossRef (data-citations), OpenCitations (OCI), DataCite, OpenAlex, SciCrunch (RRID)
+  - Supports incremental queries via date filters (`from-created-date` on CrossRef, `filter=date:>` on OpenCitations, etc.)
 - **ZoteroSync**: Handles Zotero API interaction via `pyzotero` library
   - Primary: Push discovered citations TO Zotero as nested collections
   - Optional: Import items FROM Zotero collection as source of DOIs to track

--- a/.specify/specs/tasks.md
+++ b/.specify/specs/tasks.md
@@ -94,7 +94,7 @@ description: "Implementation tasks for citations-collector project"
 - [ ] T039 [P2] Implement AbstractDiscoverer in `src/citations_collector/discovery/base.py`
 - [ ] T040 [P2] Implement CrossRefDiscoverer in `src/citations_collector/discovery/crossref.py`
   - Support email for polite pool (User-Agent header)
-  - Support `since` parameter for incremental (from-index-date filter)
+  - Support `since` parameter for incremental (from-created-date filter on /beta/datacitations)
   - Graceful degradation on 404/network errors (return empty list)
 - [ ] T041 [P2] Implement OpenCitationsDiscoverer in `src/citations_collector/discovery/opencitations.py`
   - Support `since` parameter (filter=date:>YYYY-MM-DD)

--- a/src/citations_collector/discovery/crossref.py
+++ b/src/citations_collector/discovery/crossref.py
@@ -1,4 +1,10 @@
-"""CrossRef Event Data citation discovery."""
+"""CrossRef data-citations API discovery.
+
+Uses the ``/beta/datacitations`` endpoint on ``api.crossref.org``. This
+replaces the retired ``api.eventdata.crossref.org`` Event Data service,
+which CrossRef permanently shut down on 2026-04-23. See issue #7 and
+https://www.crossref.org/blog/strengthening-support-for-data-citations-and-saying-goodbye-to-event-data/
+"""
 
 from __future__ import annotations
 
@@ -30,14 +36,14 @@ def _sanitize_text(text: str | None) -> str | None:
 
 
 class CrossRefDiscoverer(AbstractDiscoverer):
-    """Discover citations via CrossRef Event Data API."""
+    """Discover citations via the CrossRef data-citations API."""
 
-    BASE_URL = "https://api.eventdata.crossref.org/v1/events"
+    BASE_URL = "https://api.crossref.org/beta/datacitations"
     DOI_API = "https://doi.org"
 
     def __init__(self, email: str | None = None) -> None:
         """
-        Initialize CrossRef Event Data discoverer.
+        Initialize CrossRef data-citations discoverer.
 
         Args:
             email: Email for polite pool (better rate limits)
@@ -60,11 +66,11 @@ class CrossRefDiscoverer(AbstractDiscoverer):
 
     def discover(self, item_ref: ItemRef, since: datetime | None = None) -> list[CitationRecord]:
         """
-        Discover citations from CrossRef Event Data.
+        Discover citations from the CrossRef data-citations API.
 
         Args:
             item_ref: DOI reference to query
-            since: Optional date for incremental updates (from-updated-date filter)
+            since: Optional date for incremental updates (from-created-date filter)
 
         Returns:
             List of citation records
@@ -76,40 +82,34 @@ class CrossRefDiscoverer(AbstractDiscoverer):
         doi = item_ref.ref_value
         logger.debug(f"CrossRef querying for DOI: {doi}")
 
-        # Query CrossRef Event Data for citations
-        # obj-id is the DOI being cited, subj-id is the citing work
-        params: dict[str, Any] = {"obj-id": doi, "rows": 1000}
+        # object-id filters citations whose *object* (cited work) is this DOI;
+        # rows=1000 is the API maximum.
+        params: dict[str, Any] = {"object-id": doi, "rows": 1000}
+        if self.email:
+            params["mailto"] = self.email
 
-        # Add date filter if provided
+        # Beta API takes YYYY-MM-DD for from-created-date (indexing timestamp).
         if since:
-            date_str = since.strftime("%Y-%m-%d")
-            params["from-updated-date"] = date_str
+            params["from-created-date"] = since.strftime("%Y-%m-%d")
 
         try:
-            # Increase timeout to 60s - Event Data API can be slow for some queries
             response = self.session.get(self.BASE_URL, params=params, timeout=60)
             response.raise_for_status()
             data = response.json()
         except requests.Timeout:
-            logger.warning(f"CrossRef Event Data API timeout for {doi} (query took >60s)")
+            logger.warning(f"CrossRef data-citations API timeout for {doi} (query took >60s)")
             return []
         except requests.RequestException as e:
-            logger.warning(f"CrossRef Event Data API error for {doi}: {e}")
+            logger.warning(f"CrossRef data-citations API error for {doi}: {e}")
             return []
 
-        # Parse citations from events
+        # Parse citations from the items array
         citations = []
-        events = data.get("message", {}).get("events", [])
+        items = data.get("message", {}).get("items", [])
 
-        for event in events:
-            # Get the citing DOI
-            subj = event.get("subj", {})
-            citing_doi_url = subj.get("pid", "")
-
-            # Extract DOI from URL (e.g., "https://doi.org/10.1234/abc" -> "10.1234/abc")
-            citing_doi = citing_doi_url.replace("https://doi.org/", "").replace(
-                "http://doi.org/", ""
-            )
+        for item in items:
+            # subject.id is the citing DOI (bare, no URL prefix)
+            citing_doi = item.get("subject", {}).get("id", "")
 
             if not citing_doi or not citing_doi.startswith("10."):
                 continue
@@ -132,11 +132,11 @@ class CrossRefDiscoverer(AbstractDiscoverer):
             )
             citations.append(citation)
 
-        # Warn if Event Data returned events but they didn't yield valid citations
-        if len(events) > 0 and len(citations) == 0:
+        # Warn if the API returned items but none were valid DOI-based citations
+        if len(items) > 0 and len(citations) == 0:
             logger.info(
-                f"CrossRef Event Data returned {len(events)} events for {doi} "
-                f"but none were valid DOI-based citations (may be news/blog references)"
+                f"CrossRef data-citations returned {len(items)} items for {doi} "
+                f"but none had valid subject DOIs"
             )
 
         # Also check metadata API if we got 0 citations total
@@ -149,7 +149,7 @@ class CrossRefDiscoverer(AbstractDiscoverer):
                     if cited_by_count > 0:
                         logger.warning(
                             f"CrossRef metadata shows {cited_by_count} citations for {doi}, "
-                            f"but Event Data API has 0 valid citations. "
+                            f"but data-citations API has 0 valid citations. "
                             f"Full cited-by data requires CrossRef membership: "
                             f"https://www.crossref.org/services/cited-by/"
                         )

--- a/tests/fixtures/responses/crossref_empty.json
+++ b/tests/fixtures/responses/crossref_empty.json
@@ -1,8 +1,10 @@
 {
   "status": "ok",
-  "message-type": "event-list",
+  "message-type": "data-citations-list",
   "message": {
     "total-results": 0,
-    "events": []
+    "items-per-page": 1000,
+    "next-page": null,
+    "items": []
   }
 }

--- a/tests/fixtures/responses/crossref_success.json
+++ b/tests/fixtures/responses/crossref_success.json
@@ -1,26 +1,40 @@
 {
   "status": "ok",
-  "message-type": "event-list",
+  "message-type": "data-citations-list",
   "message": {
     "total-results": 2,
-    "events": [
+    "items-per-page": 1000,
+    "next-page": null,
+    "items": [
       {
-        "id": "event-1",
-        "obj_id": "https://doi.org/10.1234/test.dataset",
-        "subj_id": "https://doi.org/10.1234/citing.paper1",
-        "subj": {
-          "pid": "https://doi.org/10.1234/citing.paper1"
+        "timestamp": "2024-01-15T00:00:00Z",
+        "relation": "references",
+        "subject": {
+          "id": "10.1234/citing.paper1",
+          "type": "journal-article",
+          "member": "1234",
+          "registration-agency": "Crossref"
         },
-        "relation_type_id": "cites"
+        "object": {
+          "id": "10.1234/test.dataset",
+          "type": "dataset",
+          "registration-agency": "DataCite"
+        }
       },
       {
-        "id": "event-2",
-        "obj_id": "https://doi.org/10.1234/test.dataset",
-        "subj_id": "https://doi.org/10.1234/citing.paper2",
-        "subj": {
-          "pid": "https://doi.org/10.1234/citing.paper2"
+        "timestamp": "2023-06-10T00:00:00Z",
+        "relation": "references",
+        "subject": {
+          "id": "10.1234/citing.paper2",
+          "type": "journal-article",
+          "member": "5678",
+          "registration-agency": "Crossref"
         },
-        "relation_type_id": "cites"
+        "object": {
+          "id": "10.1234/test.dataset",
+          "type": "dataset",
+          "registration-agency": "DataCite"
+        }
       }
     ]
   }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -26,11 +26,18 @@ def test_discover_command(collections_dir: Path, tmp_path: Path) -> None:
     """Test discover command."""
     collection_file = _copy_fixture(collections_dir, tmp_path)
 
-    # Mock CrossRef Event Data API
+    # Mock CrossRef data-citations API
     responses.add(
         responses.GET,
-        "https://api.eventdata.crossref.org/v1/events",
-        json={"message": {"total-results": 0, "events": []}},
+        "https://api.crossref.org/beta/datacitations",
+        json={
+            "message": {
+                "total-results": 0,
+                "items-per-page": 1000,
+                "next-page": None,
+                "items": [],
+            }
+        },
         status=200,
     )
     # Mock DataCite Events API
@@ -65,11 +72,18 @@ def test_discover_full_refresh_flag(collections_dir: Path, tmp_path: Path) -> No
     """Test discover with --full-refresh flag."""
     collection_file = _copy_fixture(collections_dir, tmp_path)
 
-    # Mock CrossRef Event Data API
+    # Mock CrossRef data-citations API
     responses.add(
         responses.GET,
-        "https://api.eventdata.crossref.org/v1/events",
-        json={"message": {"total-results": 0, "events": []}},
+        "https://api.crossref.org/beta/datacitations",
+        json={
+            "message": {
+                "total-results": 0,
+                "items-per-page": 1000,
+                "next-page": None,
+                "items": [],
+            }
+        },
         status=200,
     )
     # Mock DataCite Events API
@@ -113,8 +127,15 @@ def test_discover_email_env_var(
     with responses.RequestsMock() as rsps:
         rsps.add(
             responses.GET,
-            "https://api.eventdata.crossref.org/v1/events",
-            json={"message": {"total-results": 0, "events": []}},
+            "https://api.crossref.org/beta/datacitations",
+            json={
+                "message": {
+                    "total-results": 0,
+                    "items-per-page": 1000,
+                    "next-page": None,
+                    "items": [],
+                }
+            },
             status=200,
         )
         rsps.add(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -24,20 +24,30 @@ def test_from_yaml(collections_dir: Path) -> None:
 @responses.activate
 def test_discover_all_with_mocks(collections_dir: Path) -> None:
     """Test discover_all with mocked APIs."""
-    # Mock CrossRef Event Data API
+    # Mock CrossRef data-citations API
     responses.add(
         responses.GET,
-        "https://api.eventdata.crossref.org/v1/events",
+        "https://api.crossref.org/beta/datacitations",
         json={
             "message": {
                 "total-results": 1,
-                "events": [
+                "items-per-page": 1000,
+                "next-page": None,
+                "items": [
                     {
-                        "id": "event-1",
-                        "obj_id": "https://doi.org/10.1234/test.dataset",
-                        "subj_id": "https://doi.org/10.1234/citing.paper",
-                        "subj": {"pid": "https://doi.org/10.1234/citing.paper"},
-                        "relation_type_id": "cites",
+                        "timestamp": "2024-01-01T00:00:00Z",
+                        "relation": "references",
+                        "subject": {
+                            "id": "10.1234/citing.paper",
+                            "type": "journal-article",
+                            "member": "1234",
+                            "registration-agency": "Crossref",
+                        },
+                        "object": {
+                            "id": "10.1234/test.dataset",
+                            "type": "dataset",
+                            "registration-agency": "DataCite",
+                        },
                     }
                 ],
             }

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -21,15 +21,15 @@ from citations_collector.models import ItemRef
 @pytest.mark.ai_generated
 @responses.activate
 def test_crossref_success(responses_dir: Path) -> None:
-    """Test successful citation discovery from CrossRef Event Data."""
+    """Test successful citation discovery from the CrossRef data-citations API."""
     # Load mock response
     with open(responses_dir / "crossref_success.json") as f:
         mock_data = json.load(f)
 
-    # Mock CrossRef Event Data API
+    # Mock CrossRef data-citations API
     responses.add(
         responses.GET,
-        "https://api.eventdata.crossref.org/v1/events",
+        "https://api.crossref.org/beta/datacitations",
         json=mock_data,
         status=200,
     )
@@ -77,16 +77,24 @@ def test_crossref_success(responses_dir: Path) -> None:
 @pytest.mark.ai_generated
 @responses.activate
 def test_crossref_empty_results(responses_dir: Path) -> None:
-    """Test CrossRef Event Data with no citations."""
+    """Test CrossRef data-citations API with no citations."""
     # Load mock response
     with open(responses_dir / "crossref_empty.json") as f:
         mock_data = json.load(f)
 
-    # Mock CrossRef Event Data API
+    # Mock CrossRef data-citations API
     responses.add(
         responses.GET,
-        "https://api.eventdata.crossref.org/v1/events",
+        "https://api.crossref.org/beta/datacitations",
         json=mock_data,
+        status=200,
+    )
+
+    # The empty-results fallback also hits the works metadata endpoint
+    responses.add(
+        responses.GET,
+        "https://api.crossref.org/works/10.1234/test.dataset",
+        json={"message": {"is-referenced-by-count": 0}},
         status=200,
     )
 
@@ -108,7 +116,7 @@ def test_crossref_network_error() -> None:
     # Mock network error
     responses.add(
         responses.GET,
-        "https://api.eventdata.crossref.org/v1/events",
+        "https://api.crossref.org/beta/datacitations",
         status=500,
     )
 
@@ -167,15 +175,22 @@ def test_opencitations_discovery(responses_dir: Path) -> None:
 @responses.activate
 def test_incremental_date_filtering() -> None:
     """Test incremental discovery using date filters."""
-    # Mock CrossRef Event Data API with date filter
+    # Mock CrossRef data-citations API with date filter
     responses.add(
         responses.GET,
-        "https://api.eventdata.crossref.org/v1/events",
-        json={"message": {"total-results": 0, "events": []}},
+        "https://api.crossref.org/beta/datacitations",
+        json={
+            "message": {
+                "total-results": 0,
+                "items-per-page": 1000,
+                "next-page": None,
+                "items": [],
+            }
+        },
         status=200,
     )
 
-    # Mock CrossRef Metadata API (called when Event Data returns 0)
+    # Mock CrossRef Metadata API (called when data-citations returns 0)
     responses.add(
         responses.GET,
         "https://api.crossref.org/works/10.1234/test.dataset",
@@ -191,9 +206,11 @@ def test_incremental_date_filtering() -> None:
     since = datetime(2024, 1, 1)
     discoverer.discover(item_ref, since=since)
 
-    # Should have called Event Data API with date filter (from-updated-date for Event Data API)
-    assert len(responses.calls) == 2  # Event Data + Metadata
-    assert "from-updated-date=2024-01-01" in responses.calls[0].request.url
+    # Beta API uses from-created-date (indexing timestamp), not from-updated-date.
+    assert len(responses.calls) == 2  # data-citations + metadata
+    assert "from-created-date=2024-01-01" in responses.calls[0].request.url
+    assert "object-id=" in responses.calls[0].request.url
+    assert "10.1234" in responses.calls[0].request.url
 
 
 @pytest.mark.ai_generated


### PR DESCRIPTION
## Summary

Addresses proposal **#1** of #7 — the load-bearing migration.

CrossRef permanently retired `api.eventdata.crossref.org` on 2026-04-23 ([announcement](https://www.crossref.org/blog/strengthening-support-for-data-citations-and-saying-goodbye-to-event-data/)). Every query from `CrossRefDiscoverer` had been stalling on ~60 s connect timeouts × 3 urllib3 retries per DOI, reducing `discover` throughput to ~14 % of the DANDI collection within a 6 h CI budget. Verified today from a fresh shell that the host still refuses connections.

This PR repoints `CrossRefDiscoverer` at the replacement — `https://api.crossref.org/beta/datacitations` — and adjusts for its slightly different contract (query params, date filter name, response shape). Verified end-to-end against a DANDI DOI during development.

## Commits

- 7b6615b `Fix: migrate CrossRefDiscoverer to /beta/datacitations (Event Data shut down)`

<details><summary>Per-commit details</summary>

### 7b6615b `Fix: migrate CrossRefDiscoverer to /beta/datacitations (Event Data shut down)`

Wire-level changes to `CrossRefDiscoverer` (derived from the beta [OpenAPI spec](https://api.crossref.org/beta/datacitations/openapi)):

| aspect | Event Data (retired) | data-citations (beta) |
| --- | --- | --- |
| Base URL | `api.eventdata.crossref.org/v1/events` | `api.crossref.org/beta/datacitations` |
| Filter param | `obj-id=<DOI>` | `object-id=<DOI>` |
| Date filter | `from-updated-date=YYYY-MM-DD` | `from-created-date=YYYY-MM-DD` |
| Response array | `message.events[]` | `message.items[]` |
| Citing DOI | `events[i].subj.pid` (a `https://doi.org/…` URL, had to be stripped) | `items[i].subject.id` (bare DOI already) |
| Polite pool | User-Agent header only | User-Agent header **plus** `mailto=<email>` query param |

The empty-results fallback (calling `api.crossref.org/works/{doi}` to warn when Cited-by reports non-zero references but the citations endpoint returns zero) is unchanged and still exercised by the empty-results test.

Tests and fixtures updated to match new endpoint URL and response shape:

- `tests/fixtures/responses/crossref_{success,empty}.json` regenerated
- `tests/test_discovery.py` — three CrossRef tests: URL, empty fallback path (now also needs a mock for the `works/` endpoint), and incremental filter assertion
- `tests/test_core.py` and `tests/test_cli.py` — mocks for the CrossRef URL and response body

</details>

<details><summary>Scope note — what's <em>not</em> in this PR</summary>

Issue #7 proposes 6 items. This PR is deliberately just #1 (the migration), because:

- **#2 (per-DOI wall-clock timeout)** and **#3 (`--max-retries` knob)** are cross-cutting across all four discoverers (`crossref`, `datacite`, `openalex`, `opencitations`), so they belong in their own PR against `discovery/base.py` + the CLI, not tacked on here.
- **#4 (failure cache)** touches the TSV persistence layer or introduces a sidecar file — non-trivial design decision, deserves its own thread.
- **#5 (fail-fast health check)** is largely subsumed by #2 once #2 lands: a per-DOI wall-clock budget protects against silent-timeout endpoints too, without the false-positive risk of a pre-flight probe.
- **#6 (README doc for `--sources` escape hatch)** is a docs-only follow-up.

Happy to file follow-up issues splitting these out if #7 shouldn't stay open as a single umbrella.

</details>

## Test plan

- [x] `pytest tests/ -m "not integration"` — 241 passed
- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean
- [x] `mypy src/citations_collector/discovery/crossref.py` — clean
- [x] Manually confirmed old endpoint is dead (`curl` connect timeout) and new endpoint works for a live DANDI DOI (`10.48324/dandi.000167/0.220928.1306` → 3 citing works returned)
- [ ] Reviewer: verify against a fresh live run on the DANDI collection once merged (expected: `discover` progresses at normal rate, not stuck on CrossRef)
- [ ] Reviewer: decide whether to keep #7 as an umbrella issue for the remaining 5 proposals or split them out
